### PR TITLE
개별 보고서 500 오류 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Ace",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "",
   "author": "",
   "private": true,

--- a/src/shared/entities/user/user.repository.ts
+++ b/src/shared/entities/user/user.repository.ts
@@ -223,7 +223,7 @@ export class UserRepository extends AbstractRepository<User> {
       .getQueryAndParameters();
 
     const parameters = [...planQuery[1], limit];
-    if (page > 1) parameters.push([limit * (page - 1)]);
+    if (page > 1) parameters.push(limit * (page - 1));
     const res = await Promise.all([
       this.manager.query(
         `((${planQuery[0]}) UNION (${


### PR DESCRIPTION
보고서 가져오는 코드 중 parameters.push()에 배열이 그대로 들어가 문제가 
발생했음
Resolves #152

Commits:
- 😎 (#152) - Remove square brackets
- 🎉 (#152) - Update version - 0.39.1
