### PR TITLE
계획서 승인 미완료 시 보고서 생성 제한

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Ace",
-  "version": "0.42.5",
+  "version": "0.43.0",
   "description": "",
   "author": "",
   "private": true,

--- a/src/project/services/report.service.ts
+++ b/src/project/services/report.service.ts
@@ -25,7 +25,11 @@ export class ReportService {
   ): Promise<void> {
     if (await this.projectRepository.getReport(param))
       this.modifyReport(req, param, payload);
-    else this.createReport(param, payload);
+    else if (
+      (await this.projectRepository.findOne(param)).status.isPlanAccepted
+    )
+      this.createReport(param, payload);
+    else throw new ConflictException();
   }
 
   async createReport(

--- a/src/project/services/report.service.ts
+++ b/src/project/services/report.service.ts
@@ -36,8 +36,6 @@ export class ReportService {
     param: ProjectParamsDto,
     payload: CreateReportRequestDto,
   ): Promise<void> {
-    if (await this.projectRepository.getReport(param))
-      throw new ConflictException();
     const project = await this.projectRepository.findOne(param);
     if (!project) throw new NotFoundException();
     this.projectRepository.createReport(project.id, payload);
@@ -48,7 +46,6 @@ export class ReportService {
     param: ProjectParamsDto,
   ): Promise<GetReportResponseDto> {
     const report = await this.projectRepository.getReport(param);
-    if (!report) throw new NotFoundException();
     return {
       projectName: report.project.name,
       projectType: report.project.type,


### PR DESCRIPTION
계획서 승인이 완료되지 않았을 시 보고서가 생성되지 않도록 제한, 
중복되는 if문 체크 제거
Closes #164

Commits:
- 🍫 (#164) - Add restriction
- 💣 (#164) - Remove duplicated checking
- 🎉 (#164) - Update version - 0.43.0
