### PR TITLE
보고서 생성 시 제목에 빈 스트링 허용

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Ace",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "",
   "author": "",
   "private": true,

--- a/src/project/dto/request/create-report.dto.ts
+++ b/src/project/dto/request/create-report.dto.ts
@@ -2,7 +2,7 @@ import { IsString, Length } from 'class-validator';
 
 export class CreateReportRequestDto {
   @IsString()
-  @Length(1, 40)
+  @Length(0, 40)
   subject: string;
 
   @IsString()


### PR DESCRIPTION
보고서 생성 시 제목에 빈 스트링을 넣을 수 있도록 
길이 제한 완화
Closes #182

Commits:
- 💫 (#182) - Mitigate length limit
- 🎉 (#182) - Update version - 0.47.0
