### PR TITLE
프로젝트 상세 API의 plan/report 응답에 type 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Ace",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "",
   "author": "",
   "private": true,

--- a/src/project/dto/response/get-project.dto.ts
+++ b/src/project/dto/response/get-project.dto.ts
@@ -26,6 +26,7 @@ interface Member {
 interface ReportInfo {
   uuid: string;
   projectName: string;
+  type: string;
   status: string;
   thumbnailUrl: string;
   emoji: string;

--- a/src/project/services/project.service.ts
+++ b/src/project/services/project.service.ts
@@ -93,6 +93,7 @@ export class ProjectService {
         ? {
             uuid: project.uuid,
             projectName: project.name,
+            type: 'plan',
             status: this.getDocumentStatus(project, 'plan'),
             thumbnailUrl: project.thumbnailUrl,
             emoji: project.emoji,
@@ -102,6 +103,7 @@ export class ProjectService {
         ? {
             uuid: project.uuid,
             projectName: project.name,
+            type: 'report',
             status: this.getDocumentStatus(project, 'report'),
             thumbnailUrl: project.thumbnailUrl,
             emoji: project.emoji,


### PR DESCRIPTION
프로젝트 상세 API의 응답 중 plan, report 객체 내부에 type 프로퍼티 추가
Closes #191

Commits:
- 🍫 (#191) - Add type property to response
- 🎉 (#191) - Update version - 0.51.0
