### PR TITLE
보고서 관련 API 응답 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Ace",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "",
   "author": "",
   "private": true,

--- a/src/project/dto/response/get-project.dto.ts
+++ b/src/project/dto/response/get-project.dto.ts
@@ -1,3 +1,5 @@
+import { ReportInfo } from 'src/user/dto/response/profile-main.dto';
+
 export interface GetProjectResponseDto {
   uuid: string;
   projectName: string;
@@ -21,13 +23,4 @@ interface Member {
   studentNo: number;
   name: string;
   role: string;
-}
-
-interface ReportInfo {
-  uuid: string;
-  projectName: string;
-  type: string;
-  status: string;
-  thumbnailUrl: string;
-  emoji: string;
 }

--- a/src/project/dto/response/pending-project.dto.ts
+++ b/src/project/dto/response/pending-project.dto.ts
@@ -1,6 +1,6 @@
 export interface PendingProjectDto {
   count: number;
-  projects: Project[];
+  reports: Project[];
 }
 
 export interface Project {

--- a/src/project/services/feed.service.ts
+++ b/src/project/services/feed.service.ts
@@ -95,7 +95,7 @@ export class FeedService {
 
     return {
       count: projects[1],
-      projects: projects[0].map((project) => {
+      reports: projects[0].map((project) => {
         const { status } = project;
         const isPlanOrReport =
           status.isPlanSubmitted === true && status.isPlanAccepted !== true

--- a/src/shared/entities/user/user.repository.ts
+++ b/src/shared/entities/user/user.repository.ts
@@ -166,7 +166,10 @@ export class UserRepository extends AbstractRepository<User> {
         thumbnailurl?: string;
         emoji: string;
         type: 'PLAN' | 'REPORT';
-        submittedAt: Date;
+        isplansubmitted: boolean;
+        isplanaccepted: boolean;
+        isreportsubmitted: boolean;
+        isreportaccepted: boolean;
       }[],
       number,
     ]
@@ -179,6 +182,10 @@ export class UserRepository extends AbstractRepository<User> {
         'project.name AS projectName',
         'project.thumbnailUrl AS thumbnailUrl',
         'project.emoji AS emoji',
+        'status.isPlanSubmitted AS isPlanSubmitted',
+        'status.isPlanAccepted AS isPlanAccepted',
+        'status.isReportSubmitted AS isReportSubmitted',
+        'status.isReportAccepted AS isReportAccepted',
       ])
       .from(Project, 'project')
       .leftJoin('project.status', 'status')

--- a/src/user/dto/response/profile-main.dto.ts
+++ b/src/user/dto/response/profile-main.dto.ts
@@ -10,7 +10,7 @@ export interface ProfileMainResponseDto {
   projects: Project[];
 }
 
-export interface PendingProject {
+export interface ReportInfo {
   uuid: string;
   projectName: string;
   type: string;

--- a/src/user/dto/response/profile-main.dto.ts
+++ b/src/user/dto/response/profile-main.dto.ts
@@ -14,7 +14,7 @@ export interface PendingProject {
   uuid: string;
   projectName: string;
   type: string;
-  status: string;
+  status: 'NOT_SUBMITTED' | 'PENDING' | 'ACCEPTED' | 'REJECTED';
   thumbnailUrl: string;
   emoji: string;
 }

--- a/src/user/dto/response/profile-main.dto.ts
+++ b/src/user/dto/response/profile-main.dto.ts
@@ -5,7 +5,7 @@ export interface ProfileMainResponseDto {
   githubId?: string;
   thumbnailUrl: string;
   pendingCount: number;
-  pendingProjects?: PendingProject[];
+  pendingReports?: ReportInfo[];
   projectCount: number;
   projects: Project[];
 }

--- a/src/user/dto/response/profile-reports.dto.ts
+++ b/src/user/dto/response/profile-reports.dto.ts
@@ -1,8 +1,8 @@
-import { PendingProject } from './profile-main.dto';
+import { ReportInfo } from './profile-main.dto';
 
 interface ProjectBlock {
   count: number;
-  projects: Omit<PendingProject, 'status'>[];
+  projects: ReportInfo[];
 }
 
 export interface ProfileReportsDto {

--- a/src/user/dto/response/profile-reports.dto.ts
+++ b/src/user/dto/response/profile-reports.dto.ts
@@ -2,12 +2,12 @@ import { ReportInfo } from './profile-main.dto';
 
 interface ProjectBlock {
   count: number;
-  projects: ReportInfo[];
+  reports: ReportInfo[];
 }
 
 export interface ProfileReportsDto {
-  accepted: ProjectBlock;
-  rejected: ProjectBlock;
-  pending: ProjectBlock;
-  writing: ProjectBlock;
+  ACCEPTED: ProjectBlock;
+  REJECTED: ProjectBlock;
+  PENDING: ProjectBlock;
+  NOT_SUBMITTED: ProjectBlock;
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import * as redisStore from 'cache-manager-redis-store';
 import { ExcelModule } from 'src/excel/excel.module';
 import { FileModule } from 'src/file/file.module';
+import { ProjectModule } from 'src/project/project.module';
 import { AdminRepository } from 'src/shared/entities/admin/admin.repository';
 import { ProjectRepository } from 'src/shared/entities/project/project.repository';
 import { UserRepository } from 'src/shared/entities/user/user.repository';
@@ -24,6 +25,7 @@ import { UserService } from './user.service';
     ]),
     ExcelModule,
     FileModule,
+    ProjectModule,
   ],
   controllers: [UserController],
   providers: [UserService],

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -121,24 +121,16 @@ export class UserService {
             project.status.isPlanSubmitted && !project.status.isPlanAccepted
               ? 'PLAN'
               : 'REPORT';
-          const status = (() => {
-            switch (type) {
-              case 'PLAN':
-                if (project.status.isPlanAccepted === false) return 'DECLINED';
-                else return 'PENDING';
-              case 'REPORT':
-                if (project.status.isReportAccepted === false)
-                  return 'DECLINED';
-                else return 'PENDING';
-            }
-          })();
           return {
             uuid: project.uuid,
             projectName: project.name,
             thumbnailUrl: project.thumbnailUrl,
             emoji: project.emoji,
             type,
-            status,
+            status: this.projectService.getDocumentStatus(
+              project,
+              type.toLowerCase() as 'plan' | 'report',
+            ) as 'NOT_SUBMITTED' | 'PENDING' | 'ACCEPTED' | 'REJECTED',
           };
         })
       : undefined;
@@ -253,6 +245,10 @@ export class UserService {
           uuid: project.uuid,
           projectName: project.projectname,
           thumbnailUrl: project.thumbnailurl,
+          status: this.getDocumentStatus(
+            project,
+            project.type.toLowerCase() as 'plan' | 'report',
+          ) as 'NOT_SUBMITTED' | 'PENDING' | 'ACCEPTED' | 'REJECTED',
           emoji: project.emoji,
           type: project.type,
         };
@@ -297,6 +293,10 @@ export class UserService {
             uuid: project.uuid,
             projectName: project.projectname,
             thumbnailUrl: project.thumbnailurl,
+            status: this.getDocumentStatus(
+              project,
+              project.type.toLowerCase() as 'plan' | 'report',
+            ),
             emoji: project.emoji,
             type: project.type,
           };
@@ -341,5 +341,34 @@ export class UserService {
         name: user.name,
       })),
     };
+  }
+
+  getDocumentStatus(
+    project: {
+      isplansubmitted: boolean;
+      isplanaccepted: boolean;
+      isreportsubmitted: boolean;
+      isreportaccepted: boolean;
+    },
+    type: 'plan' | 'report',
+  ) {
+    if (type === 'plan') {
+      if (!project.isplansubmitted && project.isplanaccepted === null)
+        return 'NOT_SUBMITTED';
+      if (project.isplansubmitted && project.isplanaccepted === null)
+        return 'PENDING';
+      if (project.isplanaccepted) return 'ACCEPTED';
+      if (!project.isplansubmitted && !project.isplanaccepted)
+        return 'REJECTED';
+    }
+    if (type === 'report') {
+      if (!project.isreportsubmitted && project.isreportaccepted === null)
+        return 'NOT_SUBMITTED';
+      if (project.isreportsubmitted && project.isreportaccepted === null)
+        return 'PENDING';
+      if (project.isreportaccepted) return 'ACCEPTED';
+      if (!project.isreportsubmitted && !project.isreportaccepted)
+        return 'REJECTED';
+    }
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -11,6 +11,7 @@ import { Cache } from 'cache-manager';
 import { Request } from 'express';
 import { ExcelService } from 'src/excel/excel.service';
 import { FileService } from 'src/file/file.service';
+import { ProjectService } from 'src/project/services/project.service';
 import { AdminRepository } from 'src/shared/entities/admin/admin.repository';
 import { Project } from 'src/shared/entities/project/project.entity';
 import { UserRepository } from 'src/shared/entities/user/user.repository';
@@ -36,6 +37,7 @@ export class UserService {
     private readonly cacheManager: Cache,
     private readonly excelService: ExcelService,
     private readonly fileService: FileService,
+    private readonly projectService: ProjectService,
     private readonly userRepository: UserRepository,
   ) {}
 
@@ -142,7 +144,7 @@ export class UserService {
       thumbnailUrl: user.thumbnailUrl,
       githubId: user.githubId,
       pendingCount: pendingProjects?.length,
-      pendingProjects: pendingProjects,
+      pendingReports: pendingProjects,
       projectCount: projects[1],
       projects: projects[0].map((project) => ({
         uuid: project.uuid,
@@ -240,7 +242,7 @@ export class UserService {
       ])
     ).map((res) => ({
       count: res[1],
-      projects: res[0].map((project) => {
+      reports: res[0].map((project) => {
         return {
           uuid: project.uuid,
           projectName: project.projectname,
@@ -256,10 +258,10 @@ export class UserService {
     }));
 
     return {
-      accepted: projects[0],
-      rejected: projects[1],
-      pending: projects[2],
-      writing: projects[3],
+      ACCEPTED: projects[0],
+      REJECTED: projects[1],
+      PENDING: projects[2],
+      NOT_SUBMITTED: projects[3],
     };
   }
 
@@ -288,7 +290,7 @@ export class UserService {
     return {
       [query.type]: {
         count: projects[1],
-        projects: projects[0].map((project) => {
+        reports: projects[0].map((project) => {
           return {
             uuid: project.uuid,
             projectName: project.projectname,


### PR DESCRIPTION
보고서 관련 API의 응답에 있는 status 항목 통일, 보고서 단위 응답임에도 projects로 표기되어 있는 응답들 수정
Closes #197

Commits:
- 🍫 (#197) - Add status property to reports
- 💫 (#197) - Change import relations
- 💫 (#197) - Change property name
- 🎉 (#197) - Update version - 0.53.0
