### PR TITLE
멤버 목록에서 잘못된 배열을 소스로 사용

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Ace",
-  "version": "0.53.2",
+  "version": "0.53.3",
   "description": "",
   "author": "",
   "private": true,

--- a/src/project/services/project.service.ts
+++ b/src/project/services/project.service.ts
@@ -125,9 +125,11 @@ export class ProjectService {
   sortProjectMembers(members: Member[], userId: string): Member[] {
     const sortedMembers = [...members];
     sortedMembers.sort((a, b) => a.studentNo - b.studentNo);
-    const index = members.findIndex((member) => member.user.uuid === userId);
+    const index = sortedMembers.findIndex(
+      (member) => member.user.uuid === userId,
+    );
     if (index > -1) {
-      const user = members[index];
+      const user = sortedMembers[index];
       sortedMembers.splice(index, 1);
       sortedMembers.unshift(user);
     }


### PR DESCRIPTION
멤버 목록에서 잘못된 배열을 소스로 사용하여 잘못된 배열을 만드는 현상 해결
Resolves #204

Commits:
- 😎 (#204) - Change source array
- 🎉 (#204) - Update version - 0.53.3
