### PR TITLE
프로필 메인에 승인 대기중 보고서 갯수가 4개까지만 표시됨

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Ace",
-  "version": "0.53.4",
+  "version": "0.53.5",
   "description": "",
   "author": "",
   "private": true,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -113,12 +113,11 @@ export class UserService {
       4,
     );
 
-    const pendingProjects = isMine
-      ? (
-          (
-            await this.userRepository.getPendingProjects(user.id)
-          )[0] as Project[]
-        )?.map((project) => {
+    const pendingProjects = await this.userRepository.getPendingProjects(
+      user.id,
+    );
+    const pendingReports = isMine
+      ? pendingProjects[0]?.map((project) => {
           const type =
             project.status.isPlanSubmitted && !project.status.isPlanAccepted
               ? 'PLAN'
@@ -143,8 +142,8 @@ export class UserService {
       email: user.email,
       thumbnailUrl: user.thumbnailUrl,
       githubId: user.githubId,
-      pendingCount: pendingProjects?.length,
-      pendingReports: pendingProjects,
+      pendingCount: pendingProjects[1],
+      pendingReports,
       projectCount: projects[1],
       projects: projects[0].map((project) => ({
         uuid: project.uuid,


### PR DESCRIPTION
프로필 메인 응답에서 승인 대기중인 보고서 갯수가 최대 4개까지만 표시되는 현상 수정
Resolves #209

Commits:
- 😎 (#209) - Fix count issue
- 🎉 (#209) - Update version - 0.53.5
